### PR TITLE
dCanvas 2.0 and more

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -24,3 +24,6 @@ run *params: build
 
 pprof:
 	go tool pprof -http=:8080 cpu.pprof
+
+test:
+	go test -v ./...

--- a/cmd/dialog/ex.go
+++ b/cmd/dialog/ex.go
@@ -14,11 +14,11 @@ import (
 	"strings"
 
 	"github.com/sbtlocalization/sbt-infinity/config"
+	"github.com/sbtlocalization/sbt-infinity/dcanvas"
 	"github.com/sbtlocalization/sbt-infinity/dialog"
 	"github.com/sbtlocalization/sbt-infinity/fs"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/supersonicpineapple/go-jsoncanvas"
 	_ "golang.org/x/image/bmp"
 )
 
@@ -27,8 +27,8 @@ func NewExportCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "export [DLG-file...]",
 		Aliases: []string{"ex"},
-		Short:   "Export dialogs as JSON Canvas files",
-		Long: `Export dialogs from DLG files (with texts from TLK file) as JSON Canvas files.
+		Short:   "Export dialogs as dCanvas files",
+		Long: `Export dialogs from DLG files (with texts from TLK file) as dCanvas files.
 Creates a visual representation of dialog structures.`,
 		Args: cobra.MinimumNArgs(0),
 		RunE: runExportDialogs,
@@ -135,9 +135,9 @@ func runExportDialogs(cmd *cobra.Command, args []string) error {
 			fmt.Printf("%s: loaded %d dialogs\n", df, len(dlg.Dialogs))
 		}
 		for _, d := range dlg.Dialogs {
-			canvas := d.ToJsonCanvas()
+			canvas := d.ToDCanvas()
 			dialogName := strings.TrimSuffix(d.Id.DlgName, filepath.Ext(d.Id.DlgName))
-			fileName := filepath.Join(outputDir, fmt.Sprintf("%s-%d.canvas", dialogName, d.Id.Index))
+			fileName := filepath.Join(outputDir, fmt.Sprintf("%s-%d.d.canvas", dialogName, d.Id.Index))
 			file, err := os.Create(fileName)
 			if verbose {
 				fmt.Printf("  exporting dialog %s to %s\n", d.Id, fileName)
@@ -148,7 +148,7 @@ func runExportDialogs(cmd *cobra.Command, args []string) error {
 			}
 			defer file.Close()
 
-			err = jsoncanvas.Encode(canvas, file)
+			err = dcanvas.Encode(canvas, file)
 			if err != nil {
 				return fmt.Errorf("error encoding canvas for dialog %s: %v", d.Id, err)
 			}

--- a/cmd/sound/export.go
+++ b/cmd/sound/export.go
@@ -24,8 +24,8 @@ func NewExportCommand() *cobra.Command {
 		Use:     "export [-o output-dir] [--format wav|flac] [flags]...",
 		Aliases: []string{"ex"},
 		Short:   "Export game audio files as WAV or FLAC",
-		Long: `Export audio resources from BIF files, converting WAVC/ACM format
-to standard WAV or FLAC. Resources are read directly from the game
+		Long: `Export audio resources from BIF files, converting WAVC/ACM/Ogg Vorbis
+format to standard WAV or FLAC. Resources are read directly from the game
 via chitin.key.`,
 		Example: `  Export all sound files as WAV:
 
@@ -107,6 +107,8 @@ func runExportSound(cmd *cobra.Command, args []string) {
 			pcm, channels, sampleRate, bitsPerSample, err = snd.DecodeWavc(data)
 		} else if snd.IsACM(data) {
 			pcm, channels, sampleRate, bitsPerSample, err = snd.DecodeAcm(data)
+		} else if snd.IsOgg(data) {
+			pcm, channels, sampleRate, bitsPerSample, err = snd.DecodeOgg(data)
 		} else {
 			if verbose {
 				fmt.Printf("Skipping %s (unknown format)\n", v.FullName)

--- a/cmd/sound/sound.go
+++ b/cmd/sound/sound.go
@@ -13,7 +13,7 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sound",
 		Short: "Work with game audio files",
-		Long:  `Utilities for converting between Infinity Engine audio formats (WAVC/ACM) and standard WAV/FLAC.`,
+		Long:  `Utilities for converting between Infinity Engine audio formats (WAVC/ACM/Ogg Vorbis) and standard WAV/FLAC.`,
 	}
 
 	cmd.PersistentFlags().StringP("filter", "f", "", "Wildcard for resourse name filtering. Case insensitive.")

--- a/cmd/text/convert.go
+++ b/cmd/text/convert.go
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2026 SBT Localization https://sbt.localization.com.ua
+// SPDX-FileContributor: Serhii Olendarenko <sergey.olendarenko@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package text
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/sbtlocalization/sbt-infinity/utils"
+	"github.com/spf13/cobra"
+)
+
+func NewConvertCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "convert",
+		Aliases: []string{"cv"},
+		Short:   "Convert XLSX file to JSON",
+		Long: `Convert an XLSX file (produced by 'text export') to a JSON file.
+
+The output JSON maps string IDs to arrays of text variants:
+  {"1": ["male text", "female text"], "2": ["male text"], ...}
+
+If female text is absent, the array contains only the male text.`,
+		Example: `  Convert dialog.xlsx to JSON (stdout):
+    sbt-inf text convert --input dialog.xlsx
+
+  Convert dialog.xlsx to a file:
+    sbt-inf text convert --input dialog.xlsx --output dialog.json`,
+		Args: cobra.NoArgs,
+		RunE: runConvert,
+	}
+
+	cmd.Flags().StringP("input", "i", "", "input XLSX `file` path")
+	cmd.Flags().StringP("output", "o", "", "output JSON `file` path (default: stdout)")
+	cmd.Flags().StringP("separator", "s", " // ", "separator for male/female text variants")
+
+	cmd.MarkFlagRequired("input")
+	cmd.MarkFlagFilename("input", "xlsx")
+	cmd.MarkFlagFilename("output", "json")
+
+	return cmd
+}
+
+func runConvert(cmd *cobra.Command, args []string) error {
+	inputPath, _ := cmd.Flags().GetString("input")
+	outputPath, _ := cmd.Flags().GetString("output")
+	separator, _ := cmd.Flags().GetString("separator")
+
+	if !strings.HasSuffix(strings.ToLower(inputPath), ".xlsx") {
+		return fmt.Errorf("input file must be an xlsx file: %s", inputPath)
+	}
+
+	if _, err := os.Stat(inputPath); os.IsNotExist(err) {
+		return fmt.Errorf("input file does not exist: %s", inputPath)
+	}
+
+	rows, err := parseXlsxForTlk(inputPath)
+	if err != nil {
+		return fmt.Errorf("failed to parse XLSX file: %w", err)
+	}
+
+	jsonData, err := buildConvertJSON(rows, separator)
+	if err != nil {
+		return fmt.Errorf("failed to build JSON: %w", err)
+	}
+
+	if outputPath != "" {
+		if err := os.WriteFile(outputPath, jsonData, 0644); err != nil {
+			return fmt.Errorf("failed to write output file: %w", err)
+		}
+	} else {
+		fmt.Print(string(jsonData))
+	}
+
+	return nil
+}
+
+func buildConvertJSON(rows []xlsxTlkRow, separator string) ([]byte, error) {
+	type entry struct {
+		key   uint32
+		texts []string
+	}
+
+	var entries []entry
+	for _, row := range rows {
+		male, female, hasSplit := utils.SplitMaleFemaleText(row.Text, separator)
+		if male == "" && !hasSplit {
+			continue
+		}
+		texts := []string{male}
+		if hasSplit && female != "" {
+			texts = append(texts, female)
+		}
+		entries = append(entries, entry{key: row.Key, texts: texts})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].key < entries[j].key
+	})
+
+	result := make(map[string][]string, len(entries))
+	for _, e := range entries {
+		result[strconv.FormatUint(uint64(e.key), 10)] = e.texts
+	}
+
+	return json.MarshalIndent(result, "", "    ")
+}

--- a/cmd/text/text.go
+++ b/cmd/text/text.go
@@ -28,6 +28,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(NewLsCommand())
 	cmd.AddCommand(NewExCommand())
 	cmd.AddCommand(NewImportCommand())
+	cmd.AddCommand(NewConvertCommand())
 
 	return cmd
 }

--- a/dcanvas/dcanvas.go
+++ b/dcanvas/dcanvas.go
@@ -31,8 +31,10 @@ type Node struct {
 	NodeId        string     `json:"x-nodeId,omitempty"`
 	Character     *Character `json:"x-character,omitempty"`
 	TextId        string     `json:"x-textId,omitempty"`
+	Sound         string     `json:"x-sound,omitempty"`
 	JournalTextId string     `json:"x-journalTextId,omitempty"`
 	JournalText   string     `json:"x-journalText,omitempty"`
+	JournalSound  string     `json:"x-journalSound,omitempty"`
 	Trigger       string     `json:"x-trigger,omitempty"`
 	Action        string     `json:"x-action,omitempty"`
 }

--- a/dcanvas/dcanvas.go
+++ b/dcanvas/dcanvas.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 SBT Localization https://sbt.localization.com.ua
+// SPDX-FileContributor: Serhii Olendarenko <sergey.olendarenko@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Package dcanvas provides types for the dCanvas 2.0 format, a strict superset
+// of JSON Canvas 1.0 with x- extension fields for game dialog metadata.
+package dcanvas
+
+// Canvas is the top-level dCanvas 2.0 document.
+type Canvas struct {
+	Version string  `json:"x-dCanvasVersion"`
+	Nodes   []*Node `json:"nodes"`
+	Edges   []*Edge `json:"edges"`
+}
+
+// Node represents a canvas node with dCanvas 2.0 extension fields.
+type Node struct {
+	// Standard JSON Canvas 1.0 fields
+	ID     string `json:"id"`
+	Type   string `json:"type"`
+	X      int    `json:"x"`
+	Y      int    `json:"y"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+	Color  string `json:"color,omitempty"`
+	Text   string `json:"text"`
+
+	// dCanvas 2.0 extension fields
+	NodeRole      string     `json:"x-nodeRole"`
+	NodeId        string     `json:"x-nodeId,omitempty"`
+	Character     *Character `json:"x-character,omitempty"`
+	TextId        string     `json:"x-textId,omitempty"`
+	JournalTextId string     `json:"x-journalTextId,omitempty"`
+	JournalText   string     `json:"x-journalText,omitempty"`
+	Trigger       string     `json:"x-trigger,omitempty"`
+	Action        string     `json:"x-action,omitempty"`
+}
+
+// Edge represents a connection between two nodes with an optional condition.
+type Edge struct {
+	// Standard JSON Canvas 1.0 fields
+	ID       string `json:"id"`
+	FromNode string `json:"fromNode"`
+	FromSide string `json:"fromSide,omitempty"`
+	FromEnd  string `json:"fromEnd,omitempty"`
+	ToNode   string `json:"toNode"`
+	ToSide   string `json:"toSide,omitempty"`
+	ToEnd    string `json:"toEnd,omitempty"`
+	Color    string `json:"color,omitempty"`
+	Label    string `json:"label,omitempty"`
+
+	// dCanvas 2.0 extension field
+	Condition string `json:"x-condition,omitempty"`
+}
+
+// Character holds speaker information for a dialog node.
+type Character struct {
+	Name     string `json:"name"`
+	Portrait string `json:"portrait,omitempty"`
+}

--- a/dcanvas/dcanvas.go
+++ b/dcanvas/dcanvas.go
@@ -61,3 +61,23 @@ type Character struct {
 	Name     string `json:"name"`
 	Portrait string `json:"portrait,omitempty"`
 }
+
+// HasOverlappingNodes reports whether any two nodes in the canvas have
+// overlapping bounding boxes. Nodes that merely touch at an edge are
+// not considered overlapping (strict less-than comparison).
+func (c *Canvas) HasOverlappingNodes() bool {
+	nodes := c.Nodes
+	for i := 0; i < len(nodes); i++ {
+		a := nodes[i]
+		for j := i + 1; j < len(nodes); j++ {
+			b := nodes[j]
+			if a.X < b.X+b.Width &&
+				b.X < a.X+a.Width &&
+				a.Y < b.Y+b.Height &&
+				b.Y < a.Y+a.Height {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/dcanvas/dcanvas_test.go
+++ b/dcanvas/dcanvas_test.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2026 SBT Localization https://sbt.localization.com.ua
+// SPDX-FileContributor: Serhii Olendarenko <sergey.olendarenko@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package dcanvas
+
+import "testing"
+
+func node(x, y, w, h int) *Node {
+	return &Node{X: x, Y: y, Width: w, Height: h}
+}
+
+func TestHasOverlappingNodes_Empty(t *testing.T) {
+	c := &Canvas{}
+	if c.HasOverlappingNodes() {
+		t.Error("expected false for empty canvas")
+	}
+}
+
+func TestHasOverlappingNodes_Single(t *testing.T) {
+	c := &Canvas{Nodes: []*Node{node(0, 0, 400, 300)}}
+	if c.HasOverlappingNodes() {
+		t.Error("expected false for single node")
+	}
+}
+
+func TestHasOverlappingNodes_NoOverlap(t *testing.T) {
+	c := &Canvas{Nodes: []*Node{
+		node(0, 0, 400, 300),
+		node(600, 0, 400, 300),
+	}}
+	if c.HasOverlappingNodes() {
+		t.Error("expected false for non-overlapping nodes")
+	}
+}
+
+func TestHasOverlappingNodes_Touching(t *testing.T) {
+	// Touching at edge — not overlapping
+	c := &Canvas{Nodes: []*Node{
+		node(0, 0, 400, 300),
+		node(400, 0, 400, 300),
+	}}
+	if c.HasOverlappingNodes() {
+		t.Error("expected false for edge-touching nodes")
+	}
+}
+
+func TestHasOverlappingNodes_Overlap(t *testing.T) {
+	// Overlaps the first node by 1 pixel horizontally
+	c := &Canvas{Nodes: []*Node{
+		node(0, 0, 400, 300),
+		node(399, 0, 400, 300),
+	}}
+	if !c.HasOverlappingNodes() {
+		t.Error("expected true for overlapping nodes")
+	}
+}
+
+func TestHasOverlappingNodes_OverlapDiagonal(t *testing.T) {
+	c := &Canvas{Nodes: []*Node{
+		node(0, 0, 400, 300),
+		node(200, 150, 400, 300),
+	}}
+	if !c.HasOverlappingNodes() {
+		t.Error("expected true for diagonally overlapping nodes")
+	}
+}
+
+func TestHasOverlappingNodes_NoOverlapVertical(t *testing.T) {
+	c := &Canvas{Nodes: []*Node{
+		node(0, 0, 400, 300),
+		node(0, 500, 400, 300),
+	}}
+	if c.HasOverlappingNodes() {
+		t.Error("expected false for vertically separated nodes")
+	}
+}
+
+func TestHasOverlappingNodes_TouchingVertical(t *testing.T) {
+	// Touching vertically — not overlapping
+	c := &Canvas{Nodes: []*Node{
+		node(0, 0, 400, 300),
+		node(0, 300, 400, 300),
+	}}
+	if c.HasOverlappingNodes() {
+		t.Error("expected false for vertically touching nodes")
+	}
+}

--- a/dcanvas/io.go
+++ b/dcanvas/io.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 SBT Localization https://sbt.localization.com.ua
+// SPDX-FileContributor: Serhii Olendarenko <sergey.olendarenko@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package dcanvas
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Encode writes a Canvas as indented JSON to w.
+func Encode(c *Canvas, w io.Writer) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "\t")
+	if err := encoder.Encode(c); err != nil {
+		return fmt.Errorf("can't encode dcanvas: %w", err)
+	}
+	return nil
+}
+
+// Decode reads a Canvas from JSON in r.
+func Decode(r io.Reader) (*Canvas, error) {
+	var c Canvas
+	if err := json.NewDecoder(r).Decode(&c); err != nil {
+		return nil, fmt.Errorf("can't decode dcanvas: %w", err)
+	}
+	return &c, nil
+}

--- a/dialog/builder.go
+++ b/dialog/builder.go
@@ -291,8 +291,10 @@ func (b *DialogBuilder) loadStateWithTransitions(dialog *Dialog, origin NodeOrig
 	state := states[origin.Index]
 	trigger, triggerExists := state.GetTriggerText()
 	text := ""
+	sound := ""
 	if b.tlkFile != nil {
 		text = b.tlkFile.GetText(state.TextRef)
+		sound = b.tlkFile.GetSound(state.TextRef)
 	}
 	stateNode := &Node{
 		Type:     StateNodeType,
@@ -303,6 +305,7 @@ func (b *DialogBuilder) loadStateWithTransitions(dialog *Dialog, origin NodeOrig
 		State: &StateData{
 			TextRef:    state.TextRef,
 			Text:       text,
+			Sound:      sound,
 			HasTrigger: triggerExists,
 			Trigger:    trigger,
 		},
@@ -321,6 +324,16 @@ func (b *DialogBuilder) loadStateWithTransitions(dialog *Dialog, origin NodeOrig
 		journalTextRef, journalText, withJournalText := transition.GetJournalText(b.tlkFile)
 		action, withAction := transition.GetActionText()
 
+		var transitionSound, journalSound string
+		if b.tlkFile != nil {
+			if withText {
+				transitionSound = b.tlkFile.GetSound(textRef)
+			}
+			if withJournalText {
+				journalSound = b.tlkFile.GetSound(journalTextRef)
+			}
+		}
+
 		numChildren := 1
 		if transition.Flags.DialogEnd {
 			numChildren = 0
@@ -335,9 +348,11 @@ func (b *DialogBuilder) loadStateWithTransitions(dialog *Dialog, origin NodeOrig
 				HasText:         withText,
 				TextRef:         textRef,
 				Text:            text,
+				Sound:           transitionSound,
 				HasJournalText:  withJournalText,
 				JournalTextRef:  journalTextRef,
 				JournalText:     journalText,
+				JournalSound:    journalSound,
 				HasTrigger:      withTrigger,
 				Trigger:         trigger,
 				HasAction:       withAction,

--- a/dialog/format.go
+++ b/dialog/format.go
@@ -129,6 +129,7 @@ func newNode(d *Dialog, node *Node, dlgNameToColor map[string]string) *dcanvas.N
 	case StateNodeType:
 		cNode.NodeRole = "state"
 		cNode.TextId = fmt.Sprintf("#%d", node.State.TextRef)
+		cNode.Sound = node.State.Sound
 		cNode.Trigger = strings.TrimSpace(node.State.Trigger)
 		cNode.Text = node.State.Text
 
@@ -147,10 +148,12 @@ func newNode(d *Dialog, node *Node, dlgNameToColor map[string]string) *dcanvas.N
 		if node.Transition.HasText {
 			cNode.TextId = fmt.Sprintf("#%d", node.Transition.TextRef)
 			cNode.Text = node.Transition.Text
+			cNode.Sound = node.Transition.Sound
 		}
 		if node.Transition.HasJournalText {
 			cNode.JournalTextId = fmt.Sprintf("#%d", node.Transition.JournalTextRef)
 			cNode.JournalText = node.Transition.JournalText
+			cNode.JournalSound = node.Transition.JournalSound
 		}
 		cNode.Action = strings.TrimSpace(node.Transition.Action)
 

--- a/dialog/format.go
+++ b/dialog/format.go
@@ -7,6 +7,7 @@ package dialog
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/nulab/autog"
@@ -228,8 +229,8 @@ func newEdge(node *Node) (*dcanvas.Edge, bool) {
 func newCharacter(name, portrait string) *dcanvas.Character {
 	ch := &dcanvas.Character{Name: name}
 	portrait = strings.TrimSuffix(portrait, ".BMP")
-	if portrait != "" {
-		ch.Portrait = portrait + ".png"
+	if portrait != "" && portrait != "None" {
+		ch.Portrait = path.Join("portraits", portrait + ".png")
 	}
 	return ch
 }

--- a/dialog/format.go
+++ b/dialog/format.go
@@ -11,8 +11,7 @@ import (
 
 	"github.com/nulab/autog"
 	"github.com/nulab/autog/graph"
-	"github.com/supersonicpineapple/go-jsoncanvas/canvas"
-	"go.yaml.in/yaml/v3"
+	"github.com/sbtlocalization/sbt-infinity/dcanvas"
 )
 
 const (
@@ -26,48 +25,18 @@ var (
 	FinalTransitionColor = "1"
 )
 
-type Character struct {
-	Name     string `yaml:"name"`
-	Portrait string `yaml:"portrait"`
-}
-
-type FrontMatter struct {
-	NodeId        string     `yaml:"nodeId"`
-	Character     *Character `yaml:"character,omitempty"`
-	TextID        string     `yaml:"textId,omitempty"`
-	JournalTextID string     `yaml:"journalTextId,omitempty"`
-	Trigger       string     `yaml:"trigger,omitempty"`
-	Action        string     `yaml:"action,omitempty"`
-}
-
-func NewFrontMatter(nodeId string) *FrontMatter {
-	return &FrontMatter{
-		NodeId: nodeId,
+func (d *Dialog) ToDCanvas() *dcanvas.Canvas {
+	c := &dcanvas.Canvas{
+		Version: "2.0",
 	}
-}
-
-func (fm *FrontMatter) SetCharacter(name, portrait string) {
-	if fm.Character == nil {
-		fm.Character = &Character{}
-	}
-	fm.Character.Name = name
-	portrait = strings.TrimSuffix(portrait, ".BMP")
-	if portrait != "" {
-		fm.Character.Portrait = portrait + ".png"
-	}
-}
-
-
-func (d *Dialog) ToJsonCanvas() *canvas.Canvas {
-	c := canvas.NewCanvas()
 
 	// Create color mapping for unique DlgName values (built on-demand)
 	stateColors := []string{"3", "6", "2", "5"}
 	dlgNameToColor := make(map[string]string)
 	colorIndex := 0
 
-	edges := make(map[string]*canvas.Edge)
-	nodes := make(map[string]*canvas.Node)
+	edges := make(map[string]*dcanvas.Edge)
+	nodes := make(map[string]*dcanvas.Node)
 	layoutEdges := make([][]string, 0)
 	for _, dNode := range d.All() {
 		if dNode.IsEmptyTransition() {
@@ -83,7 +52,7 @@ func (d *Dialog) ToJsonCanvas() *canvas.Canvas {
 
 			cNode := newNode(d, dNode, dlgNameToColor)
 			if cNode != nil {
-				c.AddNodes(cNode)
+				c.Nodes = append(c.Nodes, cNode)
 				nodes[cNode.ID] = cNode
 			}
 
@@ -97,7 +66,7 @@ func (d *Dialog) ToJsonCanvas() *canvas.Canvas {
 				if !loop {
 					layoutEdges = append(layoutEdges, []string{cEdge.FromNode, cEdge.ToNode})
 				}
-				c.AddEdges(cEdge)
+				c.Edges = append(c.Edges, cEdge)
 			}
 		}
 	}
@@ -145,82 +114,67 @@ func (d *Dialog) ToJsonCanvas() *canvas.Canvas {
 	return c
 }
 
-func newNode(d *Dialog, node *Node, dlgNameToColor map[string]string) *canvas.Node {
-	cNode := canvas.Node{
+func newNode(d *Dialog, node *Node, dlgNameToColor map[string]string) *dcanvas.Node {
+	cNode := &dcanvas.Node{
 		ID:     node.String(),
+		Type:   "text",
 		X:      0,
 		Y:      0,
 		Width:  Width,
 		Height: Height,
+		NodeId: node.Origin.String(),
 	}
 
-	var sb strings.Builder
-
-	// front matter
-	sb.WriteString("---\n")
-	fm := NewFrontMatter(node.Origin.String())
 	switch node.Type {
 	case StateNodeType:
-		fm.TextID = fmt.Sprintf("#%d", node.State.TextRef)
-		fm.Trigger = strings.TrimSpace(node.State.Trigger)
+		cNode.NodeRole = "state"
+		cNode.TextId = fmt.Sprintf("#%d", node.State.TextRef)
+		cNode.Trigger = strings.TrimSpace(node.State.Trigger)
+		cNode.Text = node.State.Text
+
 		if cre, ok := d.AllCreatures[node.Origin.DlgName]; ok {
-			fm.SetCharacter(cre.LongName, cre.Portrait)
+			cNode.Character = newCharacter(cre.LongName, cre.Portrait)
 		}
-	case TransitionNodeType:
-		if node.Transition.HasText {
-			fm.TextID = fmt.Sprintf("#%d", node.Transition.TextRef)
-		}
-		if node.Transition.HasJournalText {
-			fm.JournalTextID = fmt.Sprintf("#%d", node.Transition.JournalTextRef)
-		}
-		fm.Action = strings.TrimSpace(node.Transition.Action)
-		if node.Transition.IsDialogEnd {
-			fm.SetCharacter("End dialog", "")
-		} else {
-			fm.SetCharacter("Answer", "")
-		}
-	}
 
-	fms, _ := yaml.Marshal(fm)
-	sb.Write(fms)
-	sb.WriteString("---\n")
-
-	// content
-	switch node.Type {
-	case StateNodeType:
 		if color, exists := dlgNameToColor[node.Origin.DlgName]; exists {
-			cNode.Color = &color
+			cNode.Color = color
 		} else {
-			cNode.Color = &StateColor
+			cNode.Color = StateColor
 		}
-		sb.WriteString(node.State.Text)
+
 	case TransitionNodeType:
-		if node.Transition.IsDialogEnd {
-			cNode.Color = &FinalTransitionColor
-		} else {
-			cNode.Color = &TransitionColor
-		}
-
+		cNode.NodeRole = "transition"
 		if node.Transition.HasText {
-			sb.WriteString(node.Transition.Text)
+			cNode.TextId = fmt.Sprintf("#%d", node.Transition.TextRef)
+			cNode.Text = node.Transition.Text
+		}
+		if node.Transition.HasJournalText {
+			cNode.JournalTextId = fmt.Sprintf("#%d", node.Transition.JournalTextRef)
+			cNode.JournalText = node.Transition.JournalText
+		}
+		cNode.Action = strings.TrimSpace(node.Transition.Action)
+
+		if node.Transition.IsDialogEnd {
+			cNode.Character = newCharacter("End dialog", "")
+			cNode.Color = FinalTransitionColor
+		} else {
+			cNode.Character = newCharacter("Answer", "")
+			cNode.Color = TransitionColor
 		}
 
-		if node.Transition.HasJournalText {
-			sb.WriteString("\n\n>---- JOURNAL ----<\n\n")
-			sb.WriteString(node.Transition.JournalText)
-		}
 	case ErrorNodeType:
-		cNode.Color = &FinalTransitionColor
-		sb.WriteString("**Error loading state**")
+		cNode.NodeRole = "state"
+		cNode.Color = FinalTransitionColor
+		cNode.Text = "**Error loading state**"
+
 	case LoopNodeType:
 		return nil
 	}
-	cNode.SetText(sb.String())
 
-	return &cNode
+	return cNode
 }
 
-func newEdge(node *Node) (*canvas.Edge, bool) {
+func newEdge(node *Node) (*dcanvas.Edge, bool) {
 	if node.Parent == nil {
 		return nil, false
 	}
@@ -228,12 +182,10 @@ func newEdge(node *Node) (*canvas.Edge, bool) {
 	loop := node.Type == LoopNodeType
 
 	fromNode, toNode := node.Parent.String(), node.String()
-	fromSide, toSide, toEnd := "bottom", "top", "arrow"
-	var color string
 
-	var triggerText string
+	var condition string
 	if node.Type == TransitionNodeType && node.Transition.HasTrigger {
-		triggerText = strings.TrimSpace(node.Transition.Trigger)
+		condition = strings.TrimSpace(node.Transition.Trigger)
 	}
 
 	if node.Parent.IsEmptyTransition() && node.Parent.Parent != nil {
@@ -241,25 +193,30 @@ func newEdge(node *Node) (*canvas.Edge, bool) {
 		fromNode = node.Parent.Parent.String()
 
 		if node.Parent.Type == TransitionNodeType && node.Parent.Transition.HasTrigger {
-			triggerText = strings.TrimSpace(node.Parent.Transition.Trigger)
+			condition = strings.TrimSpace(node.Parent.Transition.Trigger)
 		}
 	}
 
-	cEdge := &canvas.Edge{
-		ID:       fmt.Sprintf("%s-%s", fromNode, toNode),
-		FromNode: fromNode,
-		FromSide: &fromSide,
-		ToNode:   toNode,
-		ToSide:   &toSide,
-		ToEnd:    &toEnd,
-		Color:    &color,
-	}
-
-	if triggerText != "" {
-		cEdge.Label = &triggerText
+	cEdge := &dcanvas.Edge{
+		ID:        fmt.Sprintf("%s-%s", fromNode, toNode),
+		FromNode:  fromNode,
+		FromSide:  "bottom",
+		ToNode:    toNode,
+		ToSide:    "top",
+		ToEnd:     "arrow",
+		Condition: condition,
 	}
 
 	return cEdge, loop
+}
+
+func newCharacter(name, portrait string) *dcanvas.Character {
+	ch := &dcanvas.Character{Name: name}
+	portrait = strings.TrimSuffix(portrait, ".BMP")
+	if portrait != "" {
+		ch.Portrait = portrait + ".png"
+	}
+	return ch
 }
 
 func (n *Node) ToUrl(baseUrl string) string {

--- a/dialog/format.go
+++ b/dialog/format.go
@@ -25,7 +25,19 @@ var (
 	FinalTransitionColor = "1"
 )
 
-func (d *Dialog) ToDCanvas() *dcanvas.Canvas {
+type FormatOptions struct {
+	SoundPrefix string
+	SoundSuffix string
+}
+
+func formatSound(name, prefix, suffix string) string {
+	if name == "" {
+		return ""
+	}
+	return prefix + name + suffix
+}
+
+func (d *Dialog) ToDCanvas(opts FormatOptions) *dcanvas.Canvas {
 	c := &dcanvas.Canvas{
 		Version: "2.0",
 	}
@@ -50,7 +62,7 @@ func (d *Dialog) ToDCanvas() *dcanvas.Canvas {
 				}
 			}
 
-			cNode := newNode(d, dNode, dlgNameToColor)
+			cNode := newNode(d, dNode, dlgNameToColor, opts)
 			if cNode != nil {
 				c.Nodes = append(c.Nodes, cNode)
 				nodes[cNode.ID] = cNode
@@ -114,7 +126,7 @@ func (d *Dialog) ToDCanvas() *dcanvas.Canvas {
 	return c
 }
 
-func newNode(d *Dialog, node *Node, dlgNameToColor map[string]string) *dcanvas.Node {
+func newNode(d *Dialog, node *Node, dlgNameToColor map[string]string, opts FormatOptions) *dcanvas.Node {
 	cNode := &dcanvas.Node{
 		ID:     node.String(),
 		Type:   "text",
@@ -129,7 +141,7 @@ func newNode(d *Dialog, node *Node, dlgNameToColor map[string]string) *dcanvas.N
 	case StateNodeType:
 		cNode.NodeRole = "state"
 		cNode.TextId = fmt.Sprintf("#%d", node.State.TextRef)
-		cNode.Sound = node.State.Sound
+		cNode.Sound = formatSound(node.State.Sound, opts.SoundPrefix, opts.SoundSuffix)
 		cNode.Trigger = strings.TrimSpace(node.State.Trigger)
 		cNode.Text = node.State.Text
 
@@ -148,12 +160,12 @@ func newNode(d *Dialog, node *Node, dlgNameToColor map[string]string) *dcanvas.N
 		if node.Transition.HasText {
 			cNode.TextId = fmt.Sprintf("#%d", node.Transition.TextRef)
 			cNode.Text = node.Transition.Text
-			cNode.Sound = node.Transition.Sound
+			cNode.Sound = formatSound(node.Transition.Sound, opts.SoundPrefix, opts.SoundSuffix)
 		}
 		if node.Transition.HasJournalText {
 			cNode.JournalTextId = fmt.Sprintf("#%d", node.Transition.JournalTextRef)
 			cNode.JournalText = node.Transition.JournalText
-			cNode.JournalSound = node.Transition.JournalSound
+			cNode.JournalSound = formatSound(node.Transition.JournalSound, opts.SoundPrefix, opts.SoundSuffix)
 		}
 		cNode.Action = strings.TrimSpace(node.Transition.Action)
 

--- a/dialog/types.go
+++ b/dialog/types.go
@@ -62,6 +62,7 @@ type Node struct {
 type StateData struct {
 	TextRef    uint32
 	Text       string
+	Sound      string
 	HasTrigger bool
 	Trigger    string
 }
@@ -70,9 +71,11 @@ type TransitionData struct {
 	HasText         bool
 	TextRef         uint32
 	Text            string
+	Sound           string
 	HasJournalText  bool
 	JournalTextRef  uint32
 	JournalText     string
+	JournalSound    string
 	HasTrigger      bool
 	Trigger         string
 	HasAction       bool

--- a/fs/filter.go
+++ b/fs/filter.go
@@ -16,7 +16,7 @@ type CompiledFilter struct {
 	filter glob.Glob
 	caseSensitive bool
 	removePrefix bool //Remove `data/` prefix from input string if pattern has no slashes
-	removeExtension bool //Remove `.bif` suffix from input string if pattern has no dots
+	removeExtension bool //Remove file extension from input string if pattern has no dots
 }
 
 func CompileFilter (pattern string, caseSensitive bool, removePrefix bool, removeExtension bool) *CompiledFilter {
@@ -50,11 +50,9 @@ func (f *CompiledFilter) Match(input string) bool {
 	if f.removePrefix {
 		input, _ = strings.CutPrefix(input, "data/")
 	}
-	bifExtension := ".bif"
-	if f.removeExtension && len(input) > len(bifExtension) {
-		extension := strings.ToLower(input[len(input) - len(bifExtension):])
-		if strings.HasSuffix(extension, bifExtension) {
-			input = input[:len(input) - len(bifExtension)]
+	if f.removeExtension {
+		if idx := strings.LastIndexByte(input, '.'); idx >= 0 {
+			input = input[:idx]
 		}
 	}
 	if !f.caseSensitive {

--- a/fs/options.go
+++ b/fs/options.go
@@ -31,10 +31,12 @@ func WithBifFilter(pattern string) Option {
 	}
 }
 
-// WithContentFilter restricts the catalog to resources whose full name
-// matches the given glob pattern. Case insensitive. Empty pattern is a no-op.
+// WithContentFilter restricts the catalog to resources whose name matches
+// the given glob pattern. Case insensitive. If the pattern contains no dots,
+// the file extension is stripped before matching so bare names like "ABELA01"
+// match "ABELA01.WAV". Empty pattern is a no-op.
 func WithContentFilter(pattern string) Option {
 	return func(o *fsOptions) {
-		o.contentFilter = CompileFilter(pattern, false, false, false)
+		o.contentFilter = CompileFilter(pattern, false, false, true)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,6 @@ require (
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.21.0
-	github.com/supersonicpineapple/go-jsoncanvas v0.0.0-20240323133339-233662d1418e
-	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/image v0.31.0
 )
 
@@ -39,6 +37,7 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/icza/bitio v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jfreymuth/oggvorbis v1.0.5 // indirect
+	github.com/jfreymuth/vorbis v1.0.2 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mewkiz/pkg v0.0.0-20250417130911-3f050ff8c56d // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,10 @@ github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6 h1:8UsGZ2rr2ksmEru6lTo
 github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBDIWGCdTt54nHt6EeI639SmHycLYL7FkA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jfreymuth/oggvorbis v1.0.5 h1:u+Ck+R0eLSRhgq8WTmffYnrVtSztJcYrl588DM4e3kQ=
+github.com/jfreymuth/oggvorbis v1.0.5/go.mod h1:1U4pqWmghcoVsCJJ4fRBKv9peUJMBHixthRlBeD6uII=
+github.com/jfreymuth/vorbis v1.0.2 h1:m1xH6+ZI4thH927pgKD8JOH4eaGRm18rEE9/0WKjvNE=
+github.com/jfreymuth/vorbis v1.0.2/go.mod h1:DoftRo4AznKnShRl1GxiTFCseHr4zR9BN3TWXyuzrqQ=
 github.com/kaitai-io/kaitai_struct_go_runtime v0.11.0 h1:R8HKGTIstXNu4QOwV6sg69sbIh9VPJSISi/vUEba4f8=
 github.com/kaitai-io/kaitai_struct_go_runtime v0.11.0/go.mod h1:dlqdTnlCChOxVQwsUTmGwqOVc3dc/yA//R1F/QS6yh4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/supersonicpineapple/go-jsoncanvas v0.0.0-20240323133339-233662d1418e h1:DryClf96P+vTizbxbGmIOSqe+lCdqya22HgBntEpsPw=
-github.com/supersonicpineapple/go-jsoncanvas v0.0.0-20240323133339-233662d1418e/go.mod h1:T/c3VIj7uQxr1MW6qxh9ojnsUvUv3znPF9mgoyVKhiE=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/image v0.31.0 h1:mLChjE2MV6g1S7oqbXC0/UcKijjm5fnJLUYKIYrLESA=

--- a/parser/tlk-ext.go
+++ b/parser/tlk-ext.go
@@ -59,6 +59,19 @@ func (t *TlkFile) GetText(strref uint32) string {
 	return text
 }
 
+func (t *TlkFile) GetSound(strref uint32) string {
+	if t == nil || t.Tlk == nil || strref == 0xFFFFFFFF || strref > t.NumEntries {
+		return ""
+	}
+
+	entry := t.Entries[strref]
+	if !entry.Flags.SoundExists {
+		return ""
+	}
+
+	return entry.AudioName
+}
+
 func (t *TlkFile) FileName() string {
 	return t.File.Name()
 }

--- a/sound/ogg.go
+++ b/sound/ogg.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 SBT Localization https://sbt.localization.com.ua
+// SPDX-FileContributor: Serhii Olendarenko <sergey.olendarenko@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package sound
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/jfreymuth/oggvorbis"
+)
+
+// IsOgg returns true if data starts with the OggS capture pattern.
+func IsOgg(data []byte) bool {
+	return len(data) >= 4 && string(data[0:4]) == "OggS"
+}
+
+// DecodeOgg decodes Ogg Vorbis data to raw 16-bit LE PCM samples.
+func DecodeOgg(data []byte) (pcm []byte, channels, sampleRate, bitsPerSample int, err error) {
+	if !IsOgg(data) {
+		return nil, 0, 0, 0, fmt.Errorf("not an Ogg Vorbis file")
+	}
+
+	samples, format, decErr := decodeOggSafe(data)
+	if decErr != nil {
+		return nil, 0, 0, 0, fmt.Errorf("decoding Ogg Vorbis: %w", decErr)
+	}
+
+	channels = format.Channels
+	sampleRate = format.SampleRate
+	bitsPerSample = 16 // Ogg Vorbis decoded to 16-bit PCM
+
+	// Convert interleaved float32 samples [-1.0, 1.0] to interleaved int16 LE bytes.
+	pcm = make([]byte, len(samples)*2)
+	for i, s := range samples {
+		if s > 1.0 {
+			s = 1.0
+		} else if s < -1.0 {
+			s = -1.0
+		}
+		binary.LittleEndian.PutUint16(pcm[i*2:], uint16(int16(math.Round(float64(s)*32767.0))))
+	}
+
+	return pcm, channels, sampleRate, bitsPerSample, nil
+}
+
+// decodeOggSafe wraps oggvorbis.ReadAll with panic recovery,
+// since the library panics on malformed streams.
+func decodeOggSafe(data []byte) (samples []float32, format *oggvorbis.Format, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("corrupt Ogg stream: %v", r)
+		}
+	}()
+	samples, format, err = oggvorbis.ReadAll(bytes.NewReader(data))
+	return
+}

--- a/sound/ogg_test.go
+++ b/sound/ogg_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 SBT Localization https://sbt.localization.com.ua
+// SPDX-FileContributor: Serhii Olendarenko <sergey.olendarenko@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package sound
+
+import "testing"
+
+func TestIsOgg(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{"valid OggS header", []byte("OggS\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00"), true},
+		{"RIFF header", []byte("RIFF\x00\x00\x00\x00WAVE"), false},
+		{"WAVC header", []byte("WAVCV1.0"), false},
+		{"too short", []byte("Ogg"), false},
+		{"empty", []byte{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOgg(tt.data); got != tt.want {
+				t.Errorf("IsOgg() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeOgg_NotOgg(t *testing.T) {
+	_, _, _, _, err := DecodeOgg([]byte("RIFF\x00\x00\x00\x00WAVE"))
+	if err == nil {
+		t.Error("DecodeOgg() expected error for non-Ogg data, got nil")
+	}
+}
+
+func TestDecodeOgg_InvalidStream(t *testing.T) {
+	// Valid OggS magic but garbage payload
+	data := []byte("OggS\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+	_, _, _, _, err := DecodeOgg(data)
+	if err == nil {
+		t.Error("DecodeOgg() expected error for invalid Ogg stream, got nil")
+	}
+}


### PR DESCRIPTION
- Новий формат для експорту діалогів — dCanvas 2.0 — тепер власний (хоча формально це надмножина JSON Canvas)!
- Додав до команди `dialog export` можливість записувати звіт через `--report` (текстові айдішки з діалогів, використані звуки, а також діалоги, в котрих ноди перетинаються через поганий алгоритм розміщення, що вмикається окремо з `--overlaps`).
- Читання аудіо у форматі Ogg Vorbis.
- В командах з фільтрацією по bif та ресурсах досі неправильно працював `--filter`. Наприклад, `--type wav --filter alora` не знаходив `ALORA.WAV`, хоча `--type wav --filter alora*` (з зірочкою) — знаходив. Виправлено!
- Знову додав `text convert` для запису текстів у JSON (спрощений варіант TRA) — можна використовувати з переглядачем діалогів.
- 